### PR TITLE
Enhance precision

### DIFF
--- a/src/main/java/br/unb/cic/mop/eh/ErrorType.java
+++ b/src/main/java/br/unb/cic/mop/eh/ErrorType.java
@@ -4,5 +4,6 @@ public enum ErrorType {
     UnsafeAlgorithm,
     InvalidSequenceOfMethodCalls,
     UnsatisfiedConstraint,
-    InvalidKeySize
+    InvalidKeySize,
+    InvalidKeyStoreType
 }

--- a/src/main/java/br/unb/cic/mop/eh/ErrorType.java
+++ b/src/main/java/br/unb/cic/mop/eh/ErrorType.java
@@ -3,5 +3,6 @@ package br.unb.cic.mop.eh;
 public enum ErrorType {
     UnsafeAlgorithm,
     InvalidSequenceOfMethodCalls,
-    UnsatisfiedConstraint
+    UnsatisfiedConstraint,
+    InvalidKeySize
 }

--- a/src/main/java/br/unb/cic/mop/eh/ErrorType.java
+++ b/src/main/java/br/unb/cic/mop/eh/ErrorType.java
@@ -5,5 +5,6 @@ public enum ErrorType {
     InvalidSequenceOfMethodCalls,
     UnsatisfiedConstraint,
     InvalidKeySize,
-    InvalidKeyStoreType
+    InvalidKeyStoreType,
+    UnsafeProtocol
 }

--- a/src/main/java/br/unb/cic/mop/jca/util/CipherTransformationUtil.java
+++ b/src/main/java/br/unb/cic/mop/jca/util/CipherTransformationUtil.java
@@ -31,8 +31,8 @@ public class CipherTransformationUtil {
     public static boolean isValid(String transformation) {
         List<String> modes = Arrays.asList("CBC", "GCM", "PCBC", "CTR", "CTS", "CFB", "OFB");
         HashMap<String, List<String>> padding = new HashMap<>();
-        padding.put("CBC", Arrays.asList("PKCS5Padding", "ISO10126Padding"));
-        padding.put("PCBC", Arrays.asList("PKCS5Padding", "ISO10126Padding"));
+        padding.put("CBC", Arrays.asList("PKCS5Padding", "ISO10126Padding", "PKCS5PADDING"));
+        padding.put("PCBC", Arrays.asList("PKCS5Padding", "ISO10126Padding", "PKCS5PADDING"));
         padding.put("GCM", Arrays.asList("", "NoPadding"));
         padding.put("CTR", Arrays.asList("", "NoPadding"));
         padding.put("CTS", Arrays.asList("", "NoPadding"));

--- a/src/main/mop/CipherSpec.mop
+++ b/src/main/mop/CipherSpec.mop
@@ -23,13 +23,13 @@ import static br.unb.cic.mop.jca.util.CipherTransformationUtil.*;
 CipherSpec(Cipher c) {
 
    Cipher cipher = null;
-   String transformation = "";
+   String currentTransformation = "";
 
    event g1 after(String transformation) returning(Cipher c):
      call(public static Cipher Cipher.getInstance(String)) &&
      args(transformation) &&
      condition(isValid(transformation)) {
-       this.transformation = transformation;
+       currentTransformation = transformation;
        cipher = c;
    }
 
@@ -37,7 +37,7 @@ CipherSpec(Cipher c) {
       call(public static Cipher Cipher.getInstance(String, String)) &&
       args(transformation, provider) &&
       condition(isValid(transformation)) {
-        this.transformation = transformation;
+        currentTransformation = transformation;
         cipher = c;
    }
 
@@ -46,20 +46,29 @@ CipherSpec(Cipher c) {
      call(public static Cipher Cipher.getInstance(String)) &&
      args(transformation) &&
      condition(!isValid(transformation)) {
-        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "CipherSpec", "" + __LOC,
-                "expecting one of {AES/CBC/PKCS5Padding, AES/PCBC/ISO10126Padding, ...} but found " + transformation + "."));
+        currentTransformation = transformation;
    }
 
    event i1 before(int mode, Certificate cert, Cipher c):
      call(public void Cipher.init(int, Certificate, ..)) &&
      args(mode, cert, ..) &&
-     target(c) { }
+     target(c) {
+       if (!isValid(currentTransformation)) {
+            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "CipherSpec", "" + __LOC,
+        "expecting one of {AES/CBC/PKCS5Padding, AES/PCBC/ISO10126Padding, ...} but found " + currentTransformation + "."));
+        }
+    }
 
    event i2 before(int mode, Key key, Cipher c):
      call(public void Cipher.init(int, Key,..)) &&
      args(mode, key, ..) &&
      target(c) &&
-     condition(ExecutionContext.instance().validate(Property.GENERATED_KEY, key)){ }
+     condition(ExecutionContext.instance().validate(Property.GENERATED_KEY, key)){
+        if (!isValid(currentTransformation)) {
+        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "CipherSpec", "" + __LOC,
+        "expecting one of {AES/CBC/PKCS5Padding, AES/PCBC/ISO10126Padding, ...} but found " + currentTransformation + "."));
+        }
+    }
 
    event u1 after (byte[] plainText, Cipher c) returning(byte[] cipherText):
      call(public byte[] Cipher.update(byte[])) &&
@@ -144,8 +153,14 @@ CipherSpec(Cipher c) {
 
    fsm :
      start [
+        g3 -> unsafeAlg
         g1 -> s1
         g2 -> s1
+     ]
+     unsafeAlg [
+        g3 -> unsafeAlg
+        g1 -> s1
+        g2 -> s2
      ]
      s1 [
        i1 -> s2

--- a/src/main/mop/KeyGeneratorSpec.mop
+++ b/src/main/mop/KeyGeneratorSpec.mop
@@ -18,8 +18,8 @@ import br.unb.cic.mop.ExecutionContext;
  */
 KeyGeneratorSpec(KeyGenerator k) {
 
-    List<String> algorithms = Arrays.asList("AES", "HmacSHA256", "HmacSHA384", "HmacSHA512");
-
+    List<String> safeAlgorithms = Arrays.asList("AES", "HmacSHA256", "HmacSHA384", "HmacSHA512");
+    String currentAlgorithmInstance = "";
     KeyGenerator keyGenerator = null;
 
     Key generatedKey;
@@ -27,23 +27,24 @@ KeyGeneratorSpec(KeyGenerator k) {
     event g1 after(String alg) returning(KeyGenerator k):
       call(public static KeyGenerator KeyGenerator.getInstance(String))
       && args(alg)
-      && condition(algorithms.contains(alg)) {
+      && condition(safeAlgorithms.contains(alg)) {
         keyGenerator = k;
+        currentAlgorithmInstance = alg;
     }
 
     event g2 after(String alg) returning(KeyGenerator k):
       call(public static KeyGenerator KeyGenerator.getInstance(String, ..))
       && args(alg, *)
-      && condition(algorithms.contains(alg)) {
+      && condition(safeAlgorithms.contains(alg)) {
         keyGenerator = k;
+        currentAlgorithmInstance = alg;
     }
 
     event g3 after(String alg) returning(KeyGenerator k):
       call(public static KeyGenerator KeyGenerator.getInstance(String))
       && args(alg)
-      && condition(!algorithms.contains(alg))  {
-        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyGeneratorSpec", "" + __LOC,
-          "one of" + String.join(",", algorithms) + " but found " + alg + "."));
+      && condition(!safeAlgorithms.contains(currentAlgorithmInstance))  {
+        currentAlgorithmInstance = alg;
     }
 
     event init before(KeyGenerator k):
@@ -57,11 +58,15 @@ KeyGeneratorSpec(KeyGenerator k) {
     event gk1 after(KeyGenerator k) returning(SecretKey key):
       call(public SecretKey KeyGenerator.generateKey())
       && target(k) {
+        if (!safeAlgorithms.contains(currentAlgorithmInstance)) {
+            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyGeneratorSpec", "" + __LOC,
+        "one of" + String.join(",", safeAlgorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
         generatedKey = key;
         ExecutionContext.instance().setProperty(ExecutionContext.Property.GENERATED_KEY, generatedKey);
     }
 
-    ere : (g1 | g2) ((init gk1) | gk1)
+    ere : (g3* g1+ | g3* g2+) ((init gk1) | gk1)
 
     @fail {
         ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidSequenceOfMethodCalls, "KeyGeneratorSpec", "" + __LOC));

--- a/src/main/mop/KeyManagerFactorySpec.mop
+++ b/src/main/mop/KeyManagerFactorySpec.mop
@@ -18,36 +18,41 @@ import br.unb.cic.mop.ExecutionContext;
  */
 KeyManagerFactorySpec(KeyManagerFactory k) {
 
-    List<String> algorithms = Arrays.asList("PKIX", "SunX509");
-
+    List<String> safeAlgorithms = Arrays.asList("PKIX", "SunX509");
+    String currentAlgorithmInstance = "";
     KeyManagerFactory keyManagerFactory = null;
 
     event g1 after(String alg) returning(KeyManagerFactory k):
       call(public static KeyManagerFactory KeyManagerFactory.getInstance(String))
       && args(alg)
-      && condition(algorithms.contains(alg)) {
+      && condition(safeAlgorithms.contains(alg)) {
         keyManagerFactory = k;
+        currentAlgorithmInstance = alg;
     }
 
     event g2 after(String alg) returning(KeyManagerFactory k):
       call(public static KeyManagerFactory KeyManagerFactory.getInstance(String, ..))
       && args(alg, *)
-      && condition(algorithms.contains(alg)) {
+      && condition(safeAlgorithms.contains(alg)) {
         keyManagerFactory = k;
+        currentAlgorithmInstance = alg;
     }
 
     event g3 after(String alg) returning(KeyManagerFactory k):
       call(public static KeyManagerFactory KeyManagerFactory.getInstance(String))
       && args(alg)
-      && condition(!algorithms.contains(alg))  {
-        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyManagerFactorySpec", "" + __LOC,
-          "one of " + String.join(",", algorithms) + " but found " + alg + "."));
+      && condition(!safeAlgorithms.contains(alg))  {
+        currentAlgorithmInstance = alg;
     }
 
     event init before(KeyManagerFactory k):
        ( call(public void KeyManagerFactory.init(KeyStore, char[])) ||
          call(public void KeyManagerFactory.init(ManagerFactoryParameters))
        ) && target(k) {
+        if (safeAlgorithms.contains(currentAlgorithmInstance)) {
+            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyManagerFactorySpec", "" + __LOC,
+        "one of " + String.join(",", safeAlgorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
        ExecutionContext.instance().setProperty(ExecutionContext.Property.GENERATED_KEY_MANAGERS, keyManagerFactory);
     }
 
@@ -59,6 +64,12 @@ KeyManagerFactorySpec(KeyManagerFactory k) {
 
     fsm :
       start [
+        g3 -> unsafeAlg
+        g1 -> waitingInit
+        g2 -> waitingInit
+      ]
+      unsafeAlg [
+        g3 -> unsafeAlg
         g1 -> waitingInit
         g2 -> waitingInit
       ]

--- a/src/main/mop/KeyPairGeneratorSpec.mop
+++ b/src/main/mop/KeyPairGeneratorSpec.mop
@@ -16,7 +16,7 @@ import br.unb.cic.mop.ExecutionContext;
  */
 KeyPairGeneratorSpec(KeyPairGenerator k) {
 
-        List<String> algorithms = Arrays.asList("RSA", "EC", "DSA", "DiffieHellman", "DH");
+        List<String> safeAlgorithms = Arrays.asList("RSA", "EC", "DSA", "DiffieHellman", "DH");
 
         KeyPairGenerator kpg = null;
         KeyPair kp;
@@ -36,7 +36,7 @@ KeyPairGeneratorSpec(KeyPairGenerator k) {
         event g1 after(String alg) returning(KeyPairGenerator k):
           call(public static KeyPairGenerator KeyPairGenerator.getInstance(String)) &&
           args(alg) &&
-          condition(algorithms.contains(alg)) {
+          condition(safeAlgorithms.contains(alg)) {
             kpg = k;
             algorithm = alg;
         }
@@ -44,7 +44,7 @@ KeyPairGeneratorSpec(KeyPairGenerator k) {
         event g2 after(String alg, String provider) returning(KeyPairGenerator k):
           call(public static KeyPairGenerator KeyPairGenerator.getInstance(String, String)) &&
           args(alg, provider) &&
-          condition(algorithms.contains(alg)) {
+          condition(safeAlgorithms.contains(alg)) {
             kpg = k;
             algorithm = alg;
         }
@@ -52,16 +52,23 @@ KeyPairGeneratorSpec(KeyPairGenerator k) {
         event g3 after(String alg) returning(KeyPairGenerator k):
           call(public static KeyPairGenerator KeyPairGenerator.getInstance(String)) &&
           args(alg) &&
-          condition(!algorithms.contains(alg)) {
-             ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyPairGeneratorSpec", "" + __LOC,
-                         "one of " + String.join(",", algorithms) + " but found " + alg + "."));
+          condition(!safeAlgorithms.contains(alg)) {
+            algorithm = alg;
         }
 
+        /*
+        It can be very difficult to format code properly inside these .mop files.
+         */
         event init1 after(int keySize, KeyPairGenerator k):
           call(public void KeyPairGenerator.initialize(int)) &&
           args(keySize) &&
           target(k) &&
-          condition(validate(keySize)) { }
+          condition(validate(keySize)) {
+             if (!safeAlgorithms.contains(algorithm)) {
+                ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyPairGeneratorSpec", "" +
+        __LOC, "one of " + String.join(",", safeAlgorithms) + " but found " + algorithm + "."));
+             }
+          }
 
         event init2 after(int keySize, SecureRandom random, KeyPairGenerator k):
           call(public void KeyPairGenerator.initialize(int, SecureRandom)) &&
@@ -84,7 +91,7 @@ KeyPairGeneratorSpec(KeyPairGenerator k) {
           args(keySize) &&
           target(k) &&
           condition(!validate(keySize)) {
-             ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyPairGeneratorSpec", "" + __LOC,
+             ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidKeySize, "KeyPairGeneratorSpec", "" + __LOC,
                                    "invalid key size for algorithm " + algorithm + "."));
         }
 
@@ -95,7 +102,7 @@ KeyPairGeneratorSpec(KeyPairGenerator k) {
            ExecutionContext.instance().setProperty(Property.GENERATED_KEY_PAIR, kp);
         }
 
-        ere: (g1 | g2) (init1 | init2 | init3 | init4) gen
+        ere: (g3* g1 | g3* g2) (init1 | init2 | init3 | init4) gen
 
         @fail {
           ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidSequenceOfMethodCalls, "KeyPairGeneratorSpec", "" + __LOC));

--- a/src/main/mop/KeyStoreSpec.mop
+++ b/src/main/mop/KeyStoreSpec.mop
@@ -20,6 +20,7 @@ import br.unb.cic.mop.ExecutionContext;
 KeyStoreSpec(KeyStore ks) {
 
     List<String> types = Arrays.asList("JCEKS", "JKS", "DKS", "PKCS11", "PKCS12");
+    String currentKSType = "";
 
     KeyStore keyStore = null;
 
@@ -30,21 +31,21 @@ KeyStoreSpec(KeyStore ks) {
       && args(ksType)
       && condition(types.contains(ksType)) {
         keyStore = k;
-    }
+        currentKSType = ksType;
+      }
 
     event g2 after(String ksType) returning(KeyStore k):
       call(public static KeyStore KeyStore.getInstance(String))
       && args(ksType)
       && condition(!types.contains(ksType))  {
-         ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "KeyStoreSpec", "" + __LOC,
-           "one of" + String.join(",", types) + " but found " + ksType + "."));
+        currentKSType = ksType;
       }
 
     event load before(KeyStore k):
       call(public void KeyStore.load(..))
       && target(k) {
         ExecutionContext.instance().setProperty(ExecutionContext.Property.GENERATED_KEY_STORE, keyStore);
-    }
+      }
 
     event store before(KeyStore k):
       call(public void KeyStore.store(..))
@@ -61,11 +62,15 @@ KeyStoreSpec(KeyStore ks) {
     event gk1 after(KeyStore k) returning(Key key):
       call(public Key KeyStore.getKey(String, char[]))
       && target(k) {
+        if (!types.contains(currentKSType)) {
+            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidKeyStoreType, "KeyStoreSpec", "" + __LOC,
+        "one of" + String.join(",", types) + " but found " + currentKSType + "."));
+        }
         generatedKey = key;
         ExecutionContext.instance().setProperty(ExecutionContext.Property.GENERATED_KEY, generatedKey);
     }
 
-    ere : (g1 load (((ge1 gk1) | gk1) | (se1 store))*)+
+    ere : (g2* g1 load (((ge1 gk1) | gk1) | (se1 store))*)+
 
     @fail {
         ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidSequenceOfMethodCalls, "KeyStoreSpec", "" + __LOC));

--- a/src/main/mop/MacSpec.mop
+++ b/src/main/mop/MacSpec.mop
@@ -8,31 +8,33 @@ import br.unb.cic.mop.ExecutionContext;
 
 MacSpec(Mac m) {
 
-        List<String> algorithms = Arrays.asList("HmacSHA256", "HmacSHA384", "HmacSHA512", "HmacPBESHA1",
+        List<String> safeAlgorithms = Arrays.asList("HmacSHA256", "HmacSHA384", "HmacSHA512", "HmacPBESHA1",
            "PBEWithHmacSHA1", "PBEWithHmacSHA224", "PBEWithHmacSHA256", "PBEWithHmacSHA384", "PBEWithHmacSHA512");
+        String currentAlgorithmInstance = "";
 
         Mac mac = null;
 
         event g1 after(String alg) returning(Mac m):
           call(public static Mac Mac.getInstance(String)) &&
           args(alg) &&
-          condition(algorithms.contains(alg)) {
+          condition(safeAlgorithms.contains(alg)) {
             mac = m;
+            currentAlgorithmInstance = alg;
         }
 
         event g2 after(String alg, String provider) returning(Mac m):
           call(public static Mac Mac.getInstance(String, String)) &&
           args(alg, provider) &&
-          condition(algorithms.contains(alg)) {
+          condition(safeAlgorithms.contains(alg)) {
             mac = m;
+            currentAlgorithmInstance = alg;
         }
 
         event g3 after(String alg) returning(Mac m):
           call(public static Mac Mac.getInstance(String)) &&
           args(alg) &&
-          condition(!algorithms.contains(alg)) {
-            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "MacSpec", "" + __LOC,
-            "one of " + String.join(",", algorithms) + " but found " + alg + "."));
+          condition(!safeAlgorithms.contains(alg)) {
+            currentAlgorithmInstance = alg;
         }
 
         event i1 before(java.security.Key key, Mac m):
@@ -40,6 +42,10 @@ MacSpec(Mac m) {
           args(key) &&
           target(m) &&
           condition(ExecutionContext.instance().validate(ExecutionContext.Property.GENERATED_KEY, key)) {
+            if (!safeAlgorithms.contains(currentAlgorithmInstance)) {
+                ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "MacSpec", "" + __LOC,
+        "one of " + String.join(",", safeAlgorithms) + " but found " + currentAlgorithmInstance + "."));
+            }
 
         }
 
@@ -48,7 +54,10 @@ MacSpec(Mac m) {
           args(key, params) &&
           target(m) &&
           condition(ExecutionContext.instance().validate(ExecutionContext.Property.GENERATED_KEY, key))  {
-
+            if (!safeAlgorithms.contains(currentAlgorithmInstance)) {
+                ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "MacSpec", "" + __LOC,
+        "one of " + String.join(",", safeAlgorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
         }
 
         event update after(Mac m):
@@ -68,7 +77,7 @@ MacSpec(Mac m) {
             ExecutionContext.instance().setProperty(Property.GENERATED_MAC, output);
         }
 
-        ere : (g1 | g2) (i1 | i2) ((f1 | f2) | (update* (f1 | f2)))
+        ere : (g3* g1 | g3* g2) (i1 | i2) ((f1 | f2) | (update* (f1 | f2)))
 
         @fail {
             ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidSequenceOfMethodCalls, "MacSpec", "" + __LOC));

--- a/src/main/mop/MessageDigestSpec.mop
+++ b/src/main/mop/MessageDigestSpec.mop
@@ -96,7 +96,7 @@ MessageDigestSpec(MessageDigest digest) {
 	Allowing g3 followed by g1 or g2 will elminiate the InvalideSequenceOfMethodCalls false positive in
 	bench02.BrokenHashABPSCase1
 	*/
-	ere : (g3* g1+ | g3* g2+) (d2 | (update+ (d1 | d2 | d3)))+
+	ere : (g3* g1 | g3* g2) (d2 | (update+ (d1 | d2 | d3)))+
 
 	@fail {
            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.InvalidSequenceOfMethodCalls, "MessageDigestSpec",  "" + __LOC));

--- a/src/main/mop/SSLContextSpec.mop
+++ b/src/main/mop/SSLContextSpec.mop
@@ -20,6 +20,7 @@ import br.unb.cic.mop.ExecutionContext;
 SSLContextSpec(SSLContext ctx) {
 
    List<String> protocols = Arrays.asList("TLSV1.2", "TLSV1.3");
+   String currentProtocol = "";
 
    SSLContext context;
 
@@ -30,6 +31,7 @@ SSLContextSpec(SSLContext ctx) {
     && args(protocol)
     && condition(protocols.contains(protocol.toUpperCase())) {
       context = ctx;
+      currentProtocol = protocol;
     }
 
     event g2 after(String protocol, String provider) returning(SSLContext ctx):
@@ -37,19 +39,23 @@ SSLContextSpec(SSLContext ctx) {
       args(protocol, provider) &&
       condition(protocols.contains(protocol.toUpperCase())) {
         context = ctx;
+        currentProtocol = protocol;
     }
 
     event unsafe_protocol after(String protocol):
       call(public static SSLContext SSLContext.getInstance(String)) &&
       args(protocol) &&
       condition(!protocols.contains(protocol.toUpperCase())) {
-        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SSLContextSpec", "" + __LOC,
-                "one of {TLSv1.2, TLSv1.3} but found " + protocol + "."));
+        currentProtocol = protocol;
     }
 
    event init after(SSLContext ctx):
      call(public void SSLContext.init(KeyManager[], TrustManager[], SecureRandom)) &&
      target(ctx) {
+       if (!protocols.contains(currentProtocol.toUpperCase())) {
+        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeProtocol, "SSLContextSpec", "" + __LOC,
+        "one of {TLSv1.2, TLSv1.3} but found " + currentProtocol + "."));
+       }
        ExecutionContext.instance().setProperty(Property.GENERATE_SSL_CONTEXT, context);
    }
 

--- a/src/main/mop/SignatureSpec.mop
+++ b/src/main/mop/SignatureSpec.mop
@@ -18,6 +18,7 @@ SignatureSpec(Signature s) {
 
        List<String> algorithms = Arrays.asList("SHA256withRSA", "SHA256withECDSA", "SHA256withDSA",
             "SHA384withRSA", "SHA512withRSA", "SHA384withECDSA", "SHA512withECDSA");
+       String currentAlgorithmInstance = "";
 
        Signature signature = null;
 
@@ -26,6 +27,7 @@ SignatureSpec(Signature s) {
          args(alg) &&
          condition(algorithms.contains(alg)) {
            signature = s;
+           currentAlgorithmInstance = alg;
        }
 
        event g2 after(String alg, String provider) returning(Signature s):
@@ -33,39 +35,61 @@ SignatureSpec(Signature s) {
          args(alg, provider) &&
          condition(algorithms.contains(alg)) {
            signature = s;
+           currentAlgorithmInstance = alg;
        }
 
        event g3 after(String alg) returning(Signature s):
          call(public static Signature Signature.getInstance(String)) &&
          args(alg) &&
          condition(!algorithms.contains(alg)) {
-             ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SignatureSpec", "" + __LOC,
-                                  "one of " + String.join(",", algorithms) + " but found " + alg + "."));
+           currentAlgorithmInstance = alg;
        }
 
        event i1 before(PrivateKey privateKey, Signature s):
          call(public void Signature.initSign(PrivateKey)) &&
          args(privateKey) &&
-         target(s) { }
+         target(s) {
+           if (!algorithms.contains(currentAlgorithmInstance)) {
+              ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SignatureSpec", "" + __LOC,
+        "one of " + String.join(",", algorithms) + " but found " + currentAlgorithmInstance + "."));
+           }
+        }
 
        event i2 before(PrivateKey privateKey, SecureRandom random, Signature s):
          call(public void Signature.initSign(PrivateKey, SecureRandom)) &&
          args(privateKey, random) &&
-         target(s) { }
+         target(s) {
+              if (!algorithms.contains(currentAlgorithmInstance)) {
+               ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SignatureSpec", "" + __LOC,
+        "one of " + String.join(",", algorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
+        }
 
        event i3 before(Certificate cert, Signature s):
          call(public void Signature.initVerify(Certificate)) &&
          args(cert) &&
-         target(s) { }
+         target(s) {
+           if (!algorithms.contains(currentAlgorithmInstance)) {
+               ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SignatureSpec", "" + __LOC,
+        "one of " + String.join(",", algorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
+        }
 
        event i4 before(PublicKey key, Signature s):
          call(public void Signature.initVerify(PublicKey)) &&
          args(key) &&
-         target(s) { }
+         target(s) {
+              if (!algorithms.contains(currentAlgorithmInstance)) {
+               ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "SignatureSpec", "" + __LOC,
+        "one of " + String.join(",", algorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
+        }
 
        event update before(Signature s):
          call(public void Signature.update(..)) &&
-         target(s) { }
+         target(s) {
+
+        }
 
        event s1 after(Signature s) returning(byte[] output):
          call(public byte Signature.sign()) &&

--- a/src/main/mop/TrustManagerFactorySpec.mop
+++ b/src/main/mop/TrustManagerFactorySpec.mop
@@ -19,6 +19,7 @@ import br.unb.cic.mop.ExecutionContext;
 TrustManagerFactorySpec(TrustManagerFactory mf) {
 
     List<String> algorithms = Arrays.asList("PKIX", "SunX509");
+    String currentAlgorithmInstance = "";
 
     TrustManagerFactory trustManagerFactory = null;
 
@@ -27,6 +28,7 @@ TrustManagerFactorySpec(TrustManagerFactory mf) {
       && args(alg)
       && condition(algorithms.contains(alg)) {
         trustManagerFactory = mf;
+        currentAlgorithmInstance = alg;
     }
 
     event g2 after(String alg) returning(TrustManagerFactory mf):
@@ -34,20 +36,24 @@ TrustManagerFactorySpec(TrustManagerFactory mf) {
       && args(alg, *)
       && condition(algorithms.contains(alg)) {
         trustManagerFactory = mf;
+        currentAlgorithmInstance = alg;
     }
 
     event g3 after(String alg) returning(TrustManagerFactory k):
       call(public static TrustManagerFactory TrustManagerFactory.getInstance(String))
       && args(alg)
       && condition(!algorithms.contains(alg))  {
-        ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "TrustManagerFactorySpec", "" + __LOC,
-          "one of " + String.join(",", algorithms) + " but found " + alg + "."));
+        currentAlgorithmInstance = alg;
     }
 
     event init before(TrustManagerFactory mf):
        ( call(public void TrustManagerFactory.init(KeyStore)) ||
          call(public void TrustManagerFactory.init(ManagerFactoryParameters))
        ) && target(mf) {
+        if (!algorithms.contains(currentAlgorithmInstance)) {
+            ErrorCollector.instance().addError(new ErrorDescription(ErrorType.UnsafeAlgorithm, "TrustManagerFactorySpec", "" + __LOC,
+        "one of " + String.join(",", algorithms) + " but found " + currentAlgorithmInstance + "."));
+        }
        ExecutionContext.instance().setProperty(ExecutionContext.Property.GENERATED_TRUST_MANAGER, trustManagerFactory);
     }
 


### PR DESCRIPTION
This PR enhances the precision of specs that define `getInstance` events, by allowing unsafe instantiations of algorithms/protocols, so long as they are followed by safe instantiations. It also changes the place where UnsafeAlgorithm/UnsafeProtocol are caught to the the method calls that actually execute the algorithm